### PR TITLE
Adding foreman role

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -38,3 +38,9 @@ mod 'diamond',
   :commit => '1355a5f5052368ff44b31c73630bb5a75f46c32c'
 
 mod 'puppetlabs/mysql', '3.6.0'
+
+mod 'foreman',
+  :git    => 'https://github.com/theforeman/puppet-foreman.git',
+  :commit => 'cccd4e6a0c6f89d6b39f3e448a46ea902024b979'
+
+

--- a/hieradata/foreman.yaml
+++ b/hieradata/foreman.yaml
@@ -1,0 +1,1 @@
+roles::foreman::foreman_db_host: 'db.leebriggs.lan'

--- a/modules/roles/manifests/db.pp
+++ b/modules/roles/manifests/db.pp
@@ -8,9 +8,16 @@ class roles::db (
   include ::mysql::server::mysqltuner
   include ::mysql::bindings
 
+  $override_options = {
+    'mysqld' => {
+      'bind-address' => '0.0.0.0'
+    }
+  }
+
   class { '::mysql::server':
     root_password           => $mysql_root_password,
     remove_default_accounts => true,
+    override_options        => $override_options
   }
 
 

--- a/modules/roles/manifests/foreman.pp
+++ b/modules/roles/manifests/foreman.pp
@@ -1,0 +1,26 @@
+# Foreman role
+class roles::foreman (
+  $foreman_db_database = 'foreman',
+  $foreman_db_password = 'foreman',
+  $foreman_db_username = 'foreman',
+  $foreman_db_host = 'localhost',
+  $foreman_admin_username = 'admin',
+  $foreman_admin_password = 'admin',
+)inherits roles::base {
+
+  class { '::foreman':
+    configure_epel_repo    => false,
+    db_manage              => false,
+    db_type                => 'mysql',
+    db_host                => $foreman_db_host,
+    db_database            => $foreman_db_database,
+    db_username            => $foreman_db_username,
+    db_password            => $foreman_db_password,
+    admin_username         => $foreman_admin_username,
+    admin_password         => $foreman_admin_password,
+    ssl                    => false,
+    passenger_ruby         => '/usr/bin/ruby193-ruby',
+    passenger_ruby_package => 'ruby193-rubygem-passenger-native',
+  }
+
+}


### PR DESCRIPTION
Remove EPEL param from foreman module

Trying unset instead of a boolean for the epel repo

Adding foreman config options into role

Changing passenger ruby package name

Removing SSL temporarily

Setting the db host in hiera

Changing ruby param to use system ruby

Changing MySQL bind-addr

Fixing the bind param name

Removing ruby override now we're on EL6

Fixing EL foreman install

Removing broken plugin_prefix param